### PR TITLE
OcWrapPreparedStatement: fix bug where int being converted to float

### DIFF
--- a/src/main/java/io/opencensus/integration/jdbc/OcWrapPreparedStatement.java
+++ b/src/main/java/io/opencensus/integration/jdbc/OcWrapPreparedStatement.java
@@ -666,7 +666,7 @@ public class OcWrapPreparedStatement implements PreparedStatement {
   public void setInt(int parameterIndex, int x) throws SQLException {
     // This method doesn't go over the network:
     // https://docs.oracle.com/javase/8/docs/api/java/sql/PreparedStatement.html#setInt-int-int-
-    this.preparedStatement.setFloat(parameterIndex, x);
+    this.preparedStatement.setInt(parameterIndex, x);
   }
 
   @Override


### PR DESCRIPTION
I found a bug while using this library where the `setInt` method in the PreparedStatement wrapper is calling `setFloat` and converting ints to floats. An example where this is problematic is the following SQL statement which results in a database error because a limit parameter of `100` rows ends up being converted to `100.0`:

`select * from <x> limit ?`

I'm happy to add some tests if it's worthwhile.
