### PR TITLE
Update opencensus-java dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
     }
 }
 
-def opencensusVersion = '0.16.1'
+def opencensusVersion = '0.21.0'
 def errorProneVersion = '2.3.1'
 def findBugsJsr305Version = '3.0.2'
 


### PR DESCRIPTION
The older version was missing the bug fix to reduce high cpu usage for low qps services that was merged into `v0.18.0`