### PR TITLE
Add traced DataSource

### DIFF
--- a/src/main/java/io/opencensus/integration/jdbc/OcWrapDataSource.java
+++ b/src/main/java/io/opencensus/integration/jdbc/OcWrapDataSource.java
@@ -1,0 +1,94 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.opencensus.integration.jdbc;
+
+import io.opencensus.integration.jdbc.Observability.TraceOption;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+/**
+ * Wraps and instruments a {@link javax.sql.DataSource} instance with tracing and metrics using
+ * OpenCensus.
+ */
+public class OcWrapDataSource implements DataSource {
+
+  private final DataSource delegate;
+  private final EnumSet<TraceOption> options;
+
+  public static OcWrapDataSource wrap(final DataSource dataSource, final Set<TraceOption> options) {
+    return new OcWrapDataSource(dataSource, options);
+  }
+
+  private OcWrapDataSource(final DataSource delegate, final Set<TraceOption> options) {
+    this.delegate = delegate;
+    this.options = EnumSet.copyOf(options);
+  }
+
+  @Override
+  public Connection getConnection() throws SQLException {
+    return wrapConnection(delegate.getConnection());
+  }
+
+  @Override
+  public Connection getConnection(final String username, final String password)
+      throws SQLException {
+    return wrapConnection(delegate.getConnection(username, password));
+  }
+
+  @Override
+  public <T> T unwrap(final Class<T> iface) throws SQLException {
+    return delegate.unwrap(iface);
+  }
+
+  @Override
+  public boolean isWrapperFor(final Class<?> iface) throws SQLException {
+    return delegate.isWrapperFor(iface);
+  }
+
+  @Override
+  public PrintWriter getLogWriter() throws SQLException {
+    return delegate.getLogWriter();
+  }
+
+  @Override
+  public void setLogWriter(final PrintWriter out) throws SQLException {
+    delegate.setLogWriter(out);
+  }
+
+  @Override
+  public void setLoginTimeout(final int seconds) throws SQLException {
+    delegate.setLoginTimeout(seconds);
+  }
+
+  @Override
+  public int getLoginTimeout() throws SQLException {
+    return delegate.getLoginTimeout();
+  }
+
+  @Override
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    return delegate.getParentLogger();
+  }
+
+  private OcWrapConnection wrapConnection(final Connection connection) {
+    return new OcWrapConnection(connection, options);
+  }
+}

--- a/src/test/java/io/opencensus/integration/jdbc/OcWrapDataSourceTest.java
+++ b/src/test/java/io/opencensus/integration/jdbc/OcWrapDataSourceTest.java
@@ -1,0 +1,60 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.opencensus.integration.jdbc;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opencensus.integration.jdbc.Observability.TraceOption;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.EnumSet;
+import javax.sql.DataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OcWrapDataSourceTest {
+  private static final EnumSet<TraceOption> OPTIONS = EnumSet.noneOf(TraceOption.class);
+
+  @Mock private DataSource delegate;
+  @Mock private Connection connection;
+
+  private DataSource dataSource;
+
+  @Before
+  public void setUp() throws SQLException {
+    dataSource = OcWrapDataSource.wrap(delegate, OPTIONS);
+  }
+
+  @Test
+  public void testGetConnection() throws SQLException {
+    when(delegate.getConnection()).thenReturn(connection);
+    final Connection conn = dataSource.getConnection();
+    conn.close();
+    verify(connection).close();
+  }
+
+  @Test
+  public void testGetConnectionUserPass() throws SQLException {
+    when(delegate.getConnection("user", "pass")).thenReturn(connection);
+    final Connection conn = dataSource.getConnection("user", "pass");
+    conn.close();
+    verify(connection).close();
+  }
+}


### PR DESCRIPTION
Useful for applications that only expose a DataSource, such as when
using HikariCP.